### PR TITLE
Fix text color application using mostReadable

### DIFF
--- a/js/index.ts
+++ b/js/index.ts
@@ -76,9 +76,10 @@ import tinycolor from "./tinycolor2.js"
 			themePickerButtons[1].style.textDecoration = "none"
 			themePickerButtons[2].style.textDecoration = "underline"
 			//	Third:
-			const color = new tinycolor(bgColor)
-			const newColor = tinycolor.mostReadable(color, drColors.flat()).toString();
-			[...textElements].forEach(textElement => textElement.style.color = newColor.toString("rgb"))
+                        const color = new tinycolor(bgColor)
+                        const readableColor = tinycolor.mostReadable(color, drColors.flat())
+                        const rgb = readableColor.toString("rgb")
+                        [...textElements].forEach(textElement => textElement.style.color = rgb)
 		})
 
 	//	Define what to do when one of the format picker buttons are clicked


### PR DESCRIPTION
## Summary
- avoid converting TinyColor to string too early
- compute readable color once and reuse for text elements

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68652c6fdbc8832b9861357a28a26f5d